### PR TITLE
Make HandTracking.js W3C spec compliant

### DIFF
--- a/examples/fruitNinja/js/src/HandTracking.js
+++ b/examples/fruitNinja/js/src/HandTracking.js
@@ -12,9 +12,9 @@ HandTracking = function(canvas_width, canvas_height) {
 
   navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia;
   if (navigator.getUserMedia) {
-    navigator.getUserMedia({ video: { 'mandatory': { 'depth': true}} },
+    navigator.getUserMedia({ depth: true },
           function(stream) {
-            video.src = window.webkitURL.createObjectURL(stream);
+            video.src = window.URL.createObjectURL(stream);
             shadowCanvas.style.display="block";
             shadowCanvas.width=gameWidth;
             shadowCanvas.height=gameHeight;


### PR DESCRIPTION
Fixed getUserMedia to use mediacapture-main and mediacapture-depth spec.
